### PR TITLE
Update pip prior to package building.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This would also be where you'd set `TWINE_REPOSITORY_URL` if publishing to somet
 
 ### Inputs
 - `python_version`: a Python version that is supported by [pyenv](https://github.com/pyenv/pyenv). For example: `3.7.0`.
+- `pip_version` (optional): the pip version to use (defaults to newest), some packages may require different pip versions.
 - `subdir` (optional): if your `setup.py` (and therefore, your entire package) is in a subdirectory of your repo, put the path to it here. This will just change the working directory to the `SUBDIR` before running the rest of the script.
 
 ### Example workflow
@@ -39,5 +40,4 @@ jobs:
       env:
         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,12 @@ author: Mariam Maarouf
 description: Package and publish Python modules.
 inputs:
   python_version:
-    description: a Python version that is supported by pyenv
+    description: a Python version that is supported by pyenv.
     required: true
     default: '3.7.0'
+  pip_version:
+    description: the pip version to use (defaults to newest).
+    required: false
   subdir:
     description: if your setup.py (and therefore, your entire package) is in a subdirectory of your repo, put the path to it here.
     required: false
@@ -14,6 +17,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.python_version }}
+    - ${{ inputs.pip_version }}
     - ${{ inputs.subdir }}
 branding:
   icon: 'package'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,30 +1,35 @@
 #!/bin/bash
 
-install_python_version(){
-	pyenv install $INPUT_PYTHON_VERSION
-	pyenv global $INPUT_PYTHON_VERSION
+install_python_version() {
+  pyenv install $INPUT_PYTHON_VERSION
+  pyenv global $INPUT_PYTHON_VERSION
+  if [ ! -z $INPUT_PIP_VERSION ]; then
+    pip install pip==$INPUT_PIP_VERSION
+  else
+    pip install --upgrade pip
+  fi
 }
 
-install_build_tools(){
-	pip install --upgrade setuptools wheel twine
+install_build_tools() {
+  pip install --upgrade setuptools wheel twine
 }
 
-go_to_build_dir(){
-	if [ ! -z $INPUT_SUBDIR ]; then
-		cd $INPUT_SUBDIR
-	fi
+go_to_build_dir() {
+  if [ ! -z $INPUT_SUBDIR ]; then
+    cd $INPUT_SUBDIR
+  fi
 }
 
-check_if_setup_file_exists(){
-	if [ ! -f setup.py ]; then
-		echo "setup.py must exist in the directory that is being packaged and published."
-		exit 1
-	fi
+check_if_setup_file_exists() {
+  if [ ! -f setup.py ]; then
+    echo "setup.py must exist in the directory that is being packaged and published."
+    exit 1
+  fi
 }
 
-upload_package(){
-	python setup.py sdist bdist_wheel
-	twine upload dist/*
+upload_package() {
+  python setup.py sdist bdist_wheel
+  twine upload dist/*
 }
 
 install_python_version


### PR DESCRIPTION
Update pip prior to package building, since some python packages may require different pip versions (like cryptography).